### PR TITLE
Feature/http headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ You can install the [`statcode`](https://aur.archlinux.org/packages/statcode/) p
 
 ## Contributing
 
-This is a pretty small project (something I put together on a plane ride), but with enough help it could turn into a go-to manual for everything HTTP-related. For example, it should be possible to look up different [request headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers), e.g. running `$ statcode cache-control` and getting "Specifies directives for caching mechanisms in both requests and responses." If you'd like to help make this happen, feel free to fork the repo and contribute. 
+This is a pretty small project (something I put together on a plane ride), but with enough help it could turn into a go-to manual for everything HTTP-related. If you'd like to help make this happen, feel free to fork the repo and contribute.
 
 If you've discovered a bug or have a feature request, create an [issue](https://github.com/shobrook/statcode/issues/new) and I'll take care of it!

--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -250,7 +250,11 @@ def output_without_ui(content):
 def generate_content(status_code):
     try:
         code_descriptions, num, status_code = get_yaml_dictionary(status_code)
-        content = code_descriptions[status_code]
+        if type(status_code) is not int:
+            # Do a case insensitive key comparison for HTTP header values
+            content = [code_descriptions[key] for key in code_descriptions if key.lower() == status_code.lower()][0]
+        else:
+            content = code_descriptions[status_code]
         pile = urwid.Pile([
             urwid.Text("STATCODE: The Manual for HTTP Status Codes and Headers\n", align="center"),
             urwid.Text(("title", "STATUS MESSAGE" if num else "HEADER INFO")),

--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -279,7 +279,7 @@ def generate_content(status_code):
         padding = urwid.Padding(Scrollable(pile), left=1, right=1)
 
         return padding
-    except (KeyError):  # None is used to print "not recognized", so KeyError. Other errors have nothing to do with it
+    except KeyError:  # None is used to print "not recognized", so KeyError. Other errors have nothing to do with it
         return None
 
 def __load_file_data(num):

--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -247,14 +247,22 @@ def output_without_ui(content):
     text = ("\n".join(text.decode("utf-8") for text in canvas.text)).rstrip()
     print(text)
 
-def generate_content(status_code):
+def get_content(code_descriptions, status_code):
     try:
-        code_descriptions, num, status_code = get_yaml_dictionary(status_code)
         if type(status_code) is not int:
             # Do a case insensitive key comparison for HTTP header values
             content = [code_descriptions[key] for key in code_descriptions if key.lower() == status_code.lower()][0]
         else:
             content = code_descriptions[status_code]
+        return content
+    except (KeyError, IndexError):  # IndexError is due to looking for an invalid key
+        raise KeyError
+
+def generate_content(status_code):
+    try:
+        code_descriptions, num, status_code = get_yaml_dictionary(status_code)
+        content = get_content(code_descriptions, status_code)
+
         pile = urwid.Pile([
             urwid.Text("STATCODE: The Manual for HTTP Status Codes and Headers\n", align="center"),
             urwid.Text(("title", "STATUS MESSAGE" if num else "HEADER INFO")),
@@ -271,7 +279,7 @@ def generate_content(status_code):
         padding = urwid.Padding(Scrollable(pile), left=1, right=1)
 
         return padding
-    except KeyError:  # None is used to print "not recognized", so KeyError. Other errors have nothing to do with it
+    except (KeyError):  # None is used to print "not recognized", so KeyError. Other errors have nothing to do with it
         return None
 
 def __load_file_data(num):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,58 @@
+import statcode.statcode
+import pytest
+
+
+def test_valid_numeric_param():
+    content = None
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("200")
+    content = statcode.statcode.get_content(code_descriptions, status_code)
+    assert content is not None
+    return
+
+
+def test_invalid_numeric_param():
+    content = None
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("999")
+    try:
+        content = statcode.statcode.get_content(code_descriptions, status_code)
+    except KeyError:
+        assert content is None
+    return
+
+
+def test_header_param():
+    content = None
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("Content-Length")
+    content = statcode.statcode.get_content(code_descriptions, status_code)
+    assert content is not None
+    return
+
+
+def test_lower_case_header_param():
+    content = None
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("content-md5")
+    content = statcode.statcode.get_content(code_descriptions, status_code)
+    assert content is not None
+    return
+
+
+def test_case_insensitive_header_params():
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("cache-control")
+    first_content = statcode.statcode.get_content(code_descriptions, status_code)
+
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("Cache-Control")
+    second_content = statcode.statcode.get_content(code_descriptions, status_code)
+
+    assert first_content == second_content
+    return
+
+
+def test_invalid_header_param():
+    content = None
+    code_descriptions, num, status_code = statcode.statcode.get_yaml_dictionary("invalid_parameter")
+    try:
+        content = statcode.statcode.get_content(code_descriptions, status_code)
+    except KeyError:
+        assert content is None
+    return
+


### PR DESCRIPTION
- Add support for case insensitive comparison of header parameters
     - Previously running the following `statcode cache-control` would return the following error `Sorry, statcode doesn't recognize: cache-control`
    - After changes the following `statcode cache-control` will return the same results as `statcode Cache-Control`
- Add pytest to test functionality of parameters can execute using `pytest test_parameters.py`
- Update readme to reflect header functionality